### PR TITLE
Get API limits

### DIFF
--- a/internal/repository/sqlite.go
+++ b/internal/repository/sqlite.go
@@ -91,10 +91,6 @@ func (s *SQLite) UpdateRetrospective(ctx context.Context, retro *types.Retrospec
 		retro.Name = foundRetro.Name
 	}
 
-	if len(retro.Description) == 0 {
-		retro.Description = foundRetro.Description
-	}
-
 	sqlQuery = `UPDATE retrospectives SET name = $1, description = $2 WHERE id = $3`
 	_, err = s.conn.Exec(sqlQuery,
 		retro.Name,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,15 +1,14 @@
 package server
 
 import (
-	"database/sql"
-	"fmt"
-	"log"
-	"net/http"
-
 	"api/config"
 	"api/docs"
 	"api/internal/service"
 	"api/types"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -568,6 +567,19 @@ func (ct *controller) deleteAnswer(c *gin.Context) {
 	c.JSON(http.StatusOK, answer)
 }
 
+// getLimits godoc
+//
+//	@Summary	Get API limits
+//	@Produce	json
+//	@Success	200	{object}	types.ApiLimits	"API limits"
+//	@Failure	500	{string}	string	"Internal error"
+//	@Router		/limits [get]
+func (ct *controller) getLimits(c *gin.Context) {
+	limits := ct.service.GetLimits(c)
+
+	c.JSON(http.StatusOK, limits)
+}
+
 // @license.name	MIT
 // @license.url	https://github.com/simple-retro/api/blob/master/LICENSE
 func (c *controller) Start() {
@@ -598,6 +610,7 @@ func (c *controller) Start() {
 	api.PATCH("/retrospective/:id", c.updateRetrospective)
 	api.DELETE("/retrospective/:id", c.deleteRetrospective)
 	api.GET("/hello/:id", c.subscribeChanges)
+	api.GET("/limits", c.getLimits)
 
 	authorized := api.Group("/")
 	authorized.Use(Authenticate())

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -133,3 +133,7 @@ func (s *Service) LoadAllRetrospectives(ctx context.Context) error {
 
 	return nil
 }
+
+func (s *Service) GetLimits(ctx context.Context) *types.ApiLimits {
+	return types.GetApiLimits()
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"context"
-	"log"
-
 	"api/config"
 	"api/internal/repository"
 	"api/internal/server"
 	"api/internal/service"
+	"context"
+	"log"
 )
 
 func main() {

--- a/types/validations.go
+++ b/types/validations.go
@@ -5,20 +5,49 @@ import "fmt"
 const (
 	NAME_LIMIT   = 100
 	DESC_LIMIT   = 300
-	ANSWER_LIMIT = 300
+	ANSWER_LIMIT = 600
 )
+
+type ApiLimits struct {
+	Retrospective limits `json:"retrospective,omitempty"`
+	Question      limits `json:"question,omitempty"`
+	Answer        limits `json:"answer,omitempty"`
+}
+
+type limits struct {
+	Name        int `json:"name,omitempty"`
+	Text        int `json:"text,omitempty"`
+	Description int `json:"description,omitempty"`
+}
+
+func GetApiLimits() *ApiLimits {
+	return &ApiLimits{
+		Retrospective: limits{
+			Name:        NAME_LIMIT,
+			Description: DESC_LIMIT,
+		},
+		Question: limits{
+			Text: DESC_LIMIT,
+		},
+		Answer: limits{
+			Text: ANSWER_LIMIT,
+		},
+	}
+}
 
 func (r *RetrospectiveCreateRequest) ValidateCreate() error {
 	if len(r.Name) == 0 {
 		return fmt.Errorf("retrospective name cannot be empty")
 	}
 
-	if len(r.Name) > NAME_LIMIT {
-		return fmt.Errorf("retrospective name too big. Limit is %d", NAME_LIMIT)
+	retroLimits := GetApiLimits().Retrospective
+
+	if len(r.Name) > retroLimits.Name {
+		return fmt.Errorf("retrospective name too big. Limit is %d", retroLimits.Name)
 	}
 
-	if len(r.Description) > DESC_LIMIT {
-		return fmt.Errorf("retrospective description too big. Limit is %d", DESC_LIMIT)
+	if len(r.Description) > retroLimits.Description {
+		return fmt.Errorf("retrospective description too big. Limit is %d", retroLimits.Description)
 	}
 
 	return nil
@@ -29,11 +58,13 @@ func (r *RetrospectiveCreateRequest) ValidateUpdate() error {
 		return fmt.Errorf("nothing to do")
 	}
 
-	if len(r.Name) > NAME_LIMIT {
-		return fmt.Errorf("retrospective name too big. Limit is %d", NAME_LIMIT)
+	retroLimits := GetApiLimits().Retrospective
+
+	if len(r.Name) > retroLimits.Name {
+		return fmt.Errorf("retrospective name too big. Limit is %d", retroLimits.Description)
 	}
 
-	if len(r.Description) > DESC_LIMIT {
+	if len(r.Description) > retroLimits.Description {
 		return fmt.Errorf("retrospective description too big. Limit is %d", DESC_LIMIT)
 	}
 
@@ -45,16 +76,19 @@ func (r *QuestionCreateRequest) ValidateCreate() error {
 		return fmt.Errorf("question text cannot be empty")
 	}
 
-	if len(r.Text) > DESC_LIMIT {
-		return fmt.Errorf("question name too big. Limit is %d", NAME_LIMIT)
+	questionLimits := GetApiLimits().Question
+
+	if len(r.Text) > questionLimits.Text {
+		return fmt.Errorf("question too big. Limit is %d", questionLimits.Text)
 	}
 
 	return nil
 }
 
 func (a *AnswerCreateRequest) ValidateCreate() error {
-	if len(a.Text) > ANSWER_LIMIT {
-		return fmt.Errorf("answer text too big. Limit is %d", ANSWER_LIMIT)
+	answerLimits := GetApiLimits().Answer
+	if len(a.Text) > answerLimits.Text {
+		return fmt.Errorf("answer text too big. Limit is %d", answerLimits.Text)
 	}
 
 	if len(a.QuestionID.String()) == 0 {


### PR DESCRIPTION
Add endpoint to return API Limits in `/api/limits`

Return expected
```json
{
  "retrospective": {
    "name": 100,
    "description": 300
  },
  "question": {
    "text": 300
  },
  "answer": {
    "text": 600
  }
}

```