### PR TITLE
Implement clean up routine

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,12 @@ type Config struct {
 	Development bool   `yaml:"development"`
 	Database    Database
 	Server      Server
+	Schedule    Schedule
+}
+
+type Schedule struct {
+	CleanUpDays     int `yaml:"clean_up_days"`
+	IntervalMinutes int `yaml:"interval_minutes"`
 }
 
 type Server struct {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,3 +12,7 @@ database:
   cache: "shared"
   max_conn: 20
   schema: "database/schema.sql" 
+
+schedule:
+  clean_up_days: 1
+  interval_minutes: 1

--- a/config/config_prod.yaml
+++ b/config/config_prod.yaml
@@ -12,3 +12,7 @@ database:
   cache: "shared"
   max_conn: 20
   schema: "database/schema.sql" 
+
+schedule:
+  clean_up_days: 7
+  interval_minutes: 60

--- a/config/config_prod.yaml
+++ b/config/config_prod.yaml
@@ -14,5 +14,5 @@ database:
   schema: "database/schema.sql" 
 
 schedule:
-  clean_up_days: 7
+  clean_up_days: 30
   interval_minutes: 60

--- a/config/config_test.yaml
+++ b/config/config_test.yaml
@@ -12,3 +12,7 @@ database:
   cache: "shared"
   max_conn: 20
   schema: "../../database/schema.sql"
+
+schedule:
+  clean_up_days: 1
+  interval_minutes: 1

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2,7 +2,8 @@
 CREATE TABLE IF NOT EXISTS retrospectives (
     id          TEXT PRIMARY KEY,
     name        TEXT,
-    description TEXT
+    description TEXT,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Table for Question

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -4,11 +4,13 @@ import (
 	"api/types"
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 type Repository interface {
+	GetOldRetrospectives(ctx context.Context, date time.Time) ([]uuid.UUID, error)
 	GetAllRetrospectives(ctx context.Context) ([]uuid.UUID, error)
 	GetRetrospective(ctx context.Context, id uuid.UUID) (*types.Retrospective, error)
 	CreateRetrospective(ctx context.Context, retro *types.Retrospective) error

--- a/internal/repository/sqlite_test.go
+++ b/internal/repository/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
@@ -160,6 +161,7 @@ func TestGetRetrospective(t *testing.T) {
 		ID:          id,
 		Name:        "mtg",
 		Description: "df/dx = 0",
+		CreatedAt:   time.Now().UTC(),
 		Questions: []types.Question{
 			{
 				ID:   questionID,
@@ -176,12 +178,13 @@ func TestGetRetrospective(t *testing.T) {
 		},
 	}
 
-	sqlQuery := `INSERT INTO retrospectives (id, name, description) VALUES ($1, $2, $3)`
+	sqlQuery := `INSERT INTO retrospectives (id, name, description, created_at) VALUES ($1, $2, $3, $4)`
 	_, err = db.conn.Exec(
 		sqlQuery,
 		&retro.ID,
 		&retro.Name,
 		&retro.Description,
+		&retro.CreatedAt,
 	)
 	assert.Nilf(t, err, "error creating retrospective")
 

--- a/internal/repository/websocket.go
+++ b/internal/repository/websocket.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"api/types"
 	"context"
 	"errors"
 	"fmt"
@@ -9,8 +10,6 @@ import (
 	"net"
 	"net/http"
 	"time"
-
-	"api/types"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -67,7 +66,8 @@ func (ws *WebSocket) AddConnection(ctx context.Context, w http.ResponseWriter, r
 			continue
 		}
 
-		if netErr, ok := err.(net.Error); (ok && netErr.Timeout()) || websocket.IsUnexpectedCloseError(err) || errors.Is(err, io.EOF) {
+		if netErr, ok := err.(net.Error); (ok && netErr.Timeout()) || websocket.IsUnexpectedCloseError(err) ||
+			errors.Is(err, io.EOF) {
 			break
 		}
 
@@ -160,6 +160,10 @@ func (w *WebSocket) DeleteQuestion(ctx context.Context, id uuid.UUID) (*types.Qu
 	}
 
 	return nil, w.sendMessageToRetro(ctx, message, nil)
+}
+
+func (s *WebSocket) GetOldRetrospectives(ctx context.Context, date time.Time) ([]uuid.UUID, error) {
+	panic("unimplemented")
 }
 
 func (s *WebSocket) GetAllRetrospectives(ctx context.Context) ([]uuid.UUID, error) {

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -1,13 +1,24 @@
-package server
+package schedule
 
 import (
 	"api/config"
+	"api/internal/service"
 	"context"
 	"log"
 	"time"
 )
 
-func (c *controller) StartSchedule() {
+type schedule struct {
+	service *service.Service
+}
+
+func New(s *service.Service) *schedule {
+	return &schedule{
+		service: s,
+	}
+}
+
+func (s *schedule) Start() {
 	config := config.Get()
 	go func() {
 		ticker := time.NewTicker(time.Duration(config.Schedule.IntervalMinutes) * time.Minute)
@@ -15,16 +26,16 @@ func (c *controller) StartSchedule() {
 		for {
 			select {
 			case <-ticker.C:
-				c.CleanUp()
+				s.cleanUp()
 			}
 		}
 	}()
 }
 
-func (c *controller) CleanUp() {
+func (s *schedule) cleanUp() {
 	log.Println("starting clean up routine")
 	ctx := context.Background()
-	if err := c.service.CleanUpRetros(ctx); err != nil {
+	if err := s.service.CleanUpRetros(ctx); err != nil {
 		log.Printf("error running clean up routine: %s", err.Error())
 	}
 }

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"api/config"
+	"context"
+	"log"
+	"time"
+)
+
+func (c *controller) StartSchedule() {
+	config := config.Get()
+	go func() {
+		ticker := time.NewTicker(time.Duration(config.Schedule.IntervalMinutes) * time.Minute)
+
+		for {
+			select {
+			case <-ticker.C:
+				c.CleanUp()
+			}
+		}
+	}()
+}
+
+func (c *controller) CleanUp() {
+	log.Println("starting clean up routine")
+	ctx := context.Background()
+	if err := c.service.CleanUpRetros(ctx); err != nil {
+		log.Printf("error running clean up routine: %s", err.Error())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"api/config"
 	"api/internal/repository"
+	"api/internal/schedule"
 	"api/internal/server"
 	"api/internal/service"
 	"context"
@@ -26,12 +27,13 @@ func main() {
 	}
 
 	service := service.New(repo, wsrepo)
+	service.LoadAllRetrospectives(context.Background())
 
 	controller := server.New(service)
 
-	service.LoadAllRetrospectives(context.Background())
+	schedule := schedule.New(service)
+	schedule.Start()
 
 	log.Printf("initing service: %s", config.Name)
-	controller.StartSchedule()
 	controller.Start()
 }

--- a/main.go
+++ b/main.go
@@ -32,5 +32,6 @@ func main() {
 	service.LoadAllRetrospectives(context.Background())
 
 	log.Printf("initing service: %s", config.Name)
+	controller.StartSchedule()
 	controller.Start()
 }

--- a/types/retrospective.go
+++ b/types/retrospective.go
@@ -12,6 +12,7 @@ type Retrospective struct {
 	Description string     `json:"description"`
 	Questions   []Question `json:"questions"`
 	CreatedAt   time.Time  `json:"created_at"`
+	ExpireAt    time.Time  `json:"expire_at"`
 }
 
 type Question struct {

--- a/types/retrospective.go
+++ b/types/retrospective.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
@@ -9,6 +11,7 @@ type Retrospective struct {
 	Name        string     `json:"name"`
 	Description string     `json:"description"`
 	Questions   []Question `json:"questions"`
+	CreatedAt   time.Time  `json:"created_at"`
 }
 
 type Question struct {


### PR DESCRIPTION
The deploy of this PR requires change database, it can be made just deleting the old database file or adding manually the new required column with:

```sql
ALTER TABLE retrospectives ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP;
```