### PR TITLE
chore: bump golang version from 1.21 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux


### PR DESCRIPTION
Update the base Docker image to use Go 1.25.