### PR TITLE
Add integration test for export retrospective endpoint

### DIFF
--- a/integration_test/retrospective_test.go
+++ b/integration_test/retrospective_test.go
@@ -1,8 +1,11 @@
 package integration_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+
+	"api/types"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -240,5 +243,138 @@ func TestDeleteRetrospective(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
+func TestExportRetrospective(t *testing.T) {
+	client := NewTestClient(t)
+
+	t.Run("successfully exports retrospective as JSON", func(t *testing.T) {
+		retro, err := client.SetupRetrospective("Export JSON Test", "Test Description")
+		require.NoError(t, err)
+
+		// Create a question and answer for richer export
+		question, resp, err := client.CreateQuestion("What went well?")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		_, resp, err = client.CreateAnswer(question.ID, "Great teamwork")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		// Export as JSON
+		data, resp, err := client.ExportRetrospective(retro.ID, types.ExportTypeJSON)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), "attachment")
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), ".json")
+
+		// Verify JSON content
+		var exportedRetro types.Retrospective
+		err = json.Unmarshal(data, &exportedRetro)
+		require.NoError(t, err)
+		assert.Equal(t, retro.ID, exportedRetro.ID)
+		assert.Equal(t, "Export JSON Test", exportedRetro.Name)
+		assert.Len(t, exportedRetro.Questions, 1)
+		assert.Len(t, exportedRetro.Questions[0].Answers, 1)
+	})
+
+	t.Run("successfully exports retrospective as Markdown", func(t *testing.T) {
+		retro, err := client.SetupRetrospective("Export Markdown Test", "Markdown Description")
+		require.NoError(t, err)
+
+		// Create a question and answer
+		question, resp, err := client.CreateQuestion("What could be improved?")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		_, resp, err = client.CreateAnswer(question.ID, "Better communication")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		// Export as Markdown
+		data, resp, err := client.ExportRetrospective(retro.ID, types.ExportTypeMarkdown)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "text/markdown", resp.Header.Get("Content-Type"))
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), "attachment")
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), ".md")
+
+		// Verify Markdown content
+		content := string(data)
+		assert.Contains(t, content, "# Simple Retro")
+		assert.Contains(t, content, "## Export Markdown Test")
+		assert.Contains(t, content, "Markdown Description")
+		assert.Contains(t, content, "### What could be improved?")
+		assert.Contains(t, content, "- Better communication")
+	})
+
+	t.Run("successfully exports retrospective as PDF", func(t *testing.T) {
+		retro, err := client.SetupRetrospective("Export PDF Test", "PDF Description")
+		require.NoError(t, err)
+
+		// Create a question and answer
+		question, resp, err := client.CreateQuestion("Action items?")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		_, resp, err = client.CreateAnswer(question.ID, "Schedule follow-up meeting")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		// Export as PDF
+		data, resp, err := client.ExportRetrospective(retro.ID, types.ExportTypePDF)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/pdf", resp.Header.Get("Content-Type"))
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), "attachment")
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), ".pdf")
+
+		// Verify PDF content (check PDF magic bytes)
+		assert.True(t, len(data) > 4)
+		assert.Equal(t, "%PDF", string(data[:4]))
+	})
+
+	t.Run("exports empty retrospective", func(t *testing.T) {
+		retro, err := client.SetupRetrospective("Empty Export Test", "No questions")
+		require.NoError(t, err)
+
+		// Export as Markdown
+		data, resp, err := client.ExportRetrospective(retro.ID, types.ExportTypeMarkdown)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		content := string(data)
+		assert.Contains(t, content, "# Simple Retro")
+		assert.Contains(t, content, "## Empty Export Test")
+	})
+
+	t.Run("returns 404 for non-existent retrospective", func(t *testing.T) {
+		nonExistentID := uuid.New()
+		_, resp, err := client.ExportRetrospective(nonExistentID, types.ExportTypeJSON)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("returns 400 for unknown export type", func(t *testing.T) {
+		retro, err := client.SetupRetrospective("Unknown Type Test", "Description")
+		require.NoError(t, err)
+
+		// Export with unknown type
+		_, resp, err := client.ExportRetrospective(retro.ID, types.ExportType("UNKNOWN"))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }

--- a/integration_test/util_test.go
+++ b/integration_test/util_test.go
@@ -403,3 +403,27 @@ func GenerateString(length int) string {
 	}
 	return string(result)
 }
+
+// ExportRetrospective exports a retrospective in the specified format
+func (c *TestClient) ExportRetrospective(retroID uuid.UUID, exportType types.ExportType) ([]byte, *http.Response, error) {
+	reqBody := types.RetrospectiveExportRequest{
+		RetrospectiveID: retroID,
+		ExportType:      exportType,
+	}
+
+	resp, err := c.DoRequest(http.MethodPost, "/api/retrospective/export", reqBody, map[string]string{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp, nil
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}


### PR DESCRIPTION
This pull request adds comprehensive integration tests for the retrospective export feature, covering JSON, Markdown, and PDF formats, as well as error scenarios. It also introduces a new helper method to facilitate exporting retrospectives in tests.

**Retrospective export integration tests:**

* Added `TestExportRetrospective` to `integration_test/retrospective_test.go`, which verifies successful exports in JSON, Markdown, and PDF formats, including content checks for each format.
* Included tests for exporting empty retrospectives, handling non-existent retrospective IDs (404), and unknown export types (400).

**Test utility improvements:**

* Introduced the `ExportRetrospective` helper method in `integration_test/util_test.go` to streamline export requests in integration tests.